### PR TITLE
Add registration page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, useLocation, Navigate } from 'react-router-dom';
 import { PrivateRoute } from './components/PrivateRoute'
 import { LoginPage } from './pages/LoginPage';
+import { RegisterPage } from './pages/RegisterPage';
 import { HomePage } from './pages/HomePage';
 import { Header } from './components/Header';
 import { ListLinkPage } from './pages/Links/ListLinkPage';
@@ -15,6 +16,7 @@ function AnimatedRoutes() {
             <Routes location={location} key={location.pathname}>
                 <Route path="/" element={<HomePage />} />
                 <Route path="/login" element={<LoginPage />} />
+                <Route path="/register" element={<RegisterPage />} />
 
                 <Route element={<PrivateRoute />}>
                     <Route path="/links" element={<ListLinkPage />} />

--- a/frontend/src/animations/pageVariants.ts
+++ b/frontend/src/animations/pageVariants.ts
@@ -4,7 +4,9 @@ export const pageVariants = {
     exit: { opacity: 0, y: -20 },
 };
 
-export const pageTransition = {
+import type { Transition } from "framer-motion";
+
+export const pageTransition: Transition = {
     duration: 0.5,
-    ease: "easeInOut"
+    ease: "easeInOut",
 };

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -62,13 +62,18 @@ export function Header() {
                         Logout
                     </Button>
                 ) : (
-                    <Button
-                        asChild
-                        size="sm"
-                        className="bg-indigo-600 hover:bg-indigo-500 text-white shadow justify-self-end"
-                    >
-                        <Link to="/login">Login</Link>
-                    </Button>
+                    <div className="flex gap-2 justify-self-end">
+                        <Button
+                            asChild
+                            size="sm"
+                            className="bg-indigo-600 hover:bg-indigo-500 text-white shadow"
+                        >
+                            <Link to="/login">Login</Link>
+                        </Button>
+                        <Button asChild size="sm" variant="secondary" className="border-indigo-500 text-indigo-300">
+                            <Link to="/register">Registro</Link>
+                        </Button>
+                    </div>
                 )}
             </div>
         </motion.header>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -53,7 +53,7 @@ export function HomePage() {
                         asChild
                         className="group relative inline-flex items-center gap-2 text-base font-semibold px-8 py-3 rounded-2xl shadow-lg bg-gradient-to-r from-emerald-500 via-lime-500 to-emerald-600 hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-lime-400/80 transition"
                     >
-                        <Link to="/login" className="flex items-center gap-2">
+                        <Link to="/register" className="flex items-center gap-2">
                             Empieza ahora
                             <ArrowRight size={18} className="transition-transform group-hover:translate-x-1" />
                         </Link>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,10 +1,10 @@
 import { useAuth } from '../context/AuthProvider';
 import { motion } from "framer-motion";
 import { pageVariants, pageTransition } from "../animations/pageVariants";
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
-export const LoginPage = () => {
-    const { signIn } = useAuth();
+export const RegisterPage = () => {
+    const { signUp } = useAuth();
     const navigate = useNavigate();
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -14,7 +14,7 @@ export const LoginPage = () => {
         const pass  = e.currentTarget.password.value;
 
         try {
-            await signIn(email, pass);
+            await signUp(email, pass);
             navigate('/links');
         } catch (err) {
             console.error(err);
@@ -32,14 +32,13 @@ export const LoginPage = () => {
         >
             <motion.form
                 onSubmit={handleSubmit}
-                className="w-full max-w-sm rounded-2xl bg-gray-800/70 backdrop-blur
-                   ring-1 ring-white/10 shadow-xl"
+                className="w-full max-w-sm rounded-2xl bg-gray-800/70 backdrop-blur ring-1 ring-white/10 shadow-xl"
                 initial={{ y: 20, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ type: "spring", stiffness: 140, damping: 18, delay: 0.15 }}
             >
                 <div className="p-8 space-y-6">
-                    <h2 className="text-center text-2xl font-semibold text-gray-100">Inicia sesión</h2>
+                    <h2 className="text-center text-2xl font-semibold text-gray-100">Crea tu cuenta</h2>
 
                     <input
                         name="email"
@@ -57,14 +56,8 @@ export const LoginPage = () => {
                     />
 
                     <button type="submit" className="btn btn-primary w-full rounded-xl">
-                        Entrar
+                        Registrarse
                     </button>
-                    <p className="text-center text-sm text-gray-400">
-                        ¿No tienes cuenta?{' '}
-                        <Link to="/register" className="text-indigo-300 hover:underline">
-                            Regístrate
-                        </Link>
-                    </p>
                 </div>
             </motion.form>
         </motion.section>


### PR DESCRIPTION
## Summary
- add new RegisterPage for users
- show RegisterPage in routes
- link to registration from login, header and hero
- fix pageTransition typing

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ec8ee3aa883308b3f58f5d9459624