### PR TITLE
Update register flow

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -7,7 +7,7 @@ type AuthContextType = {
     session: Session | null | undefined;
     user: User | null;
     signIn: (email: string, password: string) => Promise<void>;
-    signUp: (email: string, password: string) => Promise<boolean>;
+    signUp: (email: string, password: string) => Promise<void>;
     signOut: () => Promise<void>;
 };
 
@@ -39,7 +39,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const signUp = async (email: string, password: string) => {
         const { data, error } = await supabase.auth.signUp({ email, password });
         if (error) throw error;
-        return !!data.session;
+
+        if (!data.session) {
+            const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+            if (signInError) throw signInError;
+        }
     };
 
     const signOut = async () => {

--- a/frontend/src/pages/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.tsx
@@ -16,10 +16,8 @@ export const RegisterPage = () => {
         const pass  = e.currentTarget.password.value;
 
         try {
-            const canNavigate = await signUp(email, pass);
-            if (canNavigate) {
-                navigate('/links');
-            }
+            await signUp(email, pass);
+            navigate('/links');
         } catch (err) {
             console.error(err);
         }


### PR DESCRIPTION
## Summary
- ensure signUp auto logs users in
- always navigate to `/links` after successful registration

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ed8059d908330a00edfa16544d720