### PR TITLE
Add react-hot-toast alerts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.19.1",
     "lucide-react": "^0.523.0",
+    "react-hot-toast": "^2.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, useLocation, Navigate } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 import { PrivateRoute } from './components/PrivateRoute'
 import { LoginPage } from './pages/Auth/LoginPage';
 import { RegisterPage } from './pages/Auth/RegisterPage';
@@ -35,6 +36,7 @@ function App() {
     return (
         <BrowserRouter>
             <Header />
+            <Toaster position="top-right" />
             <AnimatedRoutes />
         </BrowserRouter>
     );

--- a/frontend/src/pages/Links/CreateLinkPage.tsx
+++ b/frontend/src/pages/Links/CreateLinkPage.tsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import { Bookmark, Loader2, Plus, Link as LinkIcon, Tag } from "lucide-react";
 import { useCategories } from "../../hooks/useCategories";
 import { CreateCategoryDialog } from "../../components/categories/CreateCategoryDialog";
+import { toast } from "react-hot-toast";
 
 export function CreateLinkPage() {
     const { user } = useAuth();
@@ -59,10 +60,12 @@ export function CreateLinkPage() {
         try {
             setLoading(true);
             await addLink(payload);
+            toast.success("Enlace creado");
             setForm({ url: "", title: "", description: "", category_id: "", tags: [], favorite: false });
             setTagInput("");
         } catch (err) {
             console.error(err);
+            toast.error("Error al crear el enlace");
         } finally {
             setLoading(false);
         }

--- a/frontend/src/pages/Links/EditLinkPage.tsx
+++ b/frontend/src/pages/Links/EditLinkPage.tsx
@@ -7,6 +7,7 @@ import { useCategories } from "../../hooks/useCategories";
 import { CreateCategoryDialog } from "../../components/categories/CreateCategoryDialog";
 import type { Link } from "../../types/link";
 import { useAuth } from "../../context/AuthProvider";
+import { toast } from "react-hot-toast";
 
 export function EditLinkPage() {
     const { user } = useAuth();
@@ -65,9 +66,11 @@ export function EditLinkPage() {
         try {
             setLoading(true);
             await updateLink(id, payload);
+            toast.success("Enlace actualizado");
             navigate("/links");
         } catch (err) {
             console.error(err);
+            toast.error("Error al actualizar el enlace");
         } finally {
             setLoading(false);
         }

--- a/frontend/src/pages/Links/ListLinkPage.tsx
+++ b/frontend/src/pages/Links/ListLinkPage.tsx
@@ -6,6 +6,7 @@ import LinkCard from "../../components/links/LinkCard";
 import { Sparkles, Search, Star, Trash, Pencil } from "lucide-react";
 import { Link } from "react-router-dom";
 import ConfirmDeleteLinkDialog from "../../components/links/ConfirmDeleteLinkDialog";
+import { toast } from "react-hot-toast";
 
 export function ListLinkPage() {
     const { links, updateLink, deleteLink } = useLinks();
@@ -41,8 +42,10 @@ export function ListLinkPage() {
         try {
             await deleteLink(deleteModal.id);
             setDeleteModal({ open: false, id: null });
+            toast.success("Enlace eliminado");
         } catch (err) {
             console.error(err);
+            toast.error("Error al eliminar el enlace");
         }
     };
 


### PR DESCRIPTION
## Summary
- add `react-hot-toast` dependency
- show success/error toast for create, edit and delete
- include Toaster component in main app

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'react-hot-toast')*

------
https://chatgpt.com/codex/tasks/task_e_686bdaac53208330802418e8e8a90d28