### PR TITLE
Add category listing page with CRUD

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Header } from './components/Header';
 import { ListLinkPage } from './pages/Links/ListLinkPage';
 import { CreateLinkPage } from './pages/Links/CreateLinkPage';
 import EditLinkPage from './pages/Links/EditLinkPage';
+import ListCategoryPage from './pages/Categories/ListCategoryPage';
 import { AnimatePresence } from "framer-motion";
 
 function AnimatedRoutes() {
@@ -24,6 +25,7 @@ function AnimatedRoutes() {
                     <Route path="/links" element={<ListLinkPage />} />
                     <Route path="/links/new" element={<CreateLinkPage />} />
                     <Route path="/links/:id/edit" element={<EditLinkPage />} />
+                    <Route path="/categories" element={<ListCategoryPage />} />
                 </Route>
 
                 <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -41,6 +41,17 @@ export function Header() {
                         </NavLink>
 
                         <NavLink
+                            to="/categories"
+                            className={({ isActive }) =>
+                                isActive
+                                    ? "font-semibold text-indigo-300"
+                                    : "text-gray-300 hover:text-indigo-200 transition-colors"
+                            }
+                        >
+                            Categorías
+                        </NavLink>
+
+                        <NavLink
                             to="/links/new"
                             className={({ isActive }) =>
                                 isActive

--- a/frontend/src/components/categories/ConfirmDeleteCategoryDialog.tsx
+++ b/frontend/src/components/categories/ConfirmDeleteCategoryDialog.tsx
@@ -1,0 +1,68 @@
+import { Trash } from "lucide-react";
+import { useRef, useEffect, useState } from "react";
+
+interface ConfirmDeleteCategoryDialogProps {
+    open: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+    text?: string;
+}
+
+export default function ConfirmDeleteCategoryDialog({ open, onCancel, onConfirm, text }: ConfirmDeleteCategoryDialogProps) {
+    const [show, setShow] = useState(open);
+    const [animate, setAnimate] = useState(false);
+    const timeoutRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (open) {
+            setShow(true);
+            setTimeout(() => setAnimate(true), 10);
+        } else if (show) {
+            setAnimate(false);
+            timeoutRef.current = setTimeout(() => setShow(false), 200);
+        }
+        return () => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        };
+    }, [open, show]);
+
+    useEffect(() => {
+        if (!show) return;
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onCancel();
+        };
+        window.addEventListener("keydown", handleKey);
+        return () => window.removeEventListener("keydown", handleKey);
+    }, [show, onCancel]);
+
+    const backdropRef = useRef<HTMLDivElement>(null);
+    const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (e.target === backdropRef.current) onCancel();
+    };
+
+    if (!show) return null;
+
+    return (
+        <div
+            ref={backdropRef}
+            onClick={handleBackdropClick}
+            className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 transition-opacity duration-200 ${animate ? 'opacity-100' : 'opacity-0'}`}
+        >
+            <div className={`bg-gray-900 rounded-2xl p-6 shadow-xl border border-gray-800 min-w-[300px] flex flex-col items-center transform transition-all duration-200 ${animate ? 'scale-100 translate-y-0 opacity-100' : 'scale-90 translate-y-8 opacity-0'}`}>
+                <Trash size={32} className="text-red-400 mb-2" />
+                <h2 className="text-lg font-semibold mb-2">¿Eliminar categoría?</h2>
+                <p className="text-gray-400 mb-4 text-center">{text || 'Esta acción no se puede deshacer.'}</p>
+                <div className="flex gap-3">
+                    <button
+                        className="px-4 py-1 rounded-lg bg-gray-700 hover:bg-gray-600 text-gray-200"
+                        onClick={onCancel}
+                    >Cancelar</button>
+                    <button
+                        className="px-4 py-1 rounded-lg bg-red-600 hover:bg-red-700 text-white font-semibold"
+                        onClick={onConfirm}
+                    >Eliminar</button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/categories/EditCategoryDialog.tsx
+++ b/frontend/src/components/categories/EditCategoryDialog.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+
+interface EditCategoryDialogProps {
+    open: boolean;
+    initialName: string;
+    onClose: () => void;
+    onSave: (name: string) => Promise<void>;
+}
+
+export function EditCategoryDialog({ open, initialName, onClose, onSave }: EditCategoryDialogProps) {
+    const [name, setName] = useState(initialName);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        if (open) setName(initialName);
+    }, [open, initialName]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!name.trim()) {
+            setError("El nombre es obligatorio");
+            return;
+        }
+        setError("");
+        setLoading(true);
+        try {
+            await onSave(name.trim());
+            onClose();
+        } catch {
+            setError("Error al actualizar la categoría");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <AnimatePresence>
+            {open && (
+                <motion.div
+                    className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                >
+                    <motion.div
+                        className="bg-gray-900/90 border border-gray-700/40 rounded-2xl shadow-2xl p-6 w-full max-w-xs relative"
+                        initial={{ scale: 0.9, y: 40, opacity: 0 }}
+                        animate={{ scale: 1, y: 0, opacity: 1 }}
+                        exit={{ scale: 0.9, y: 40, opacity: 0 }}
+                        transition={{ type: "spring", duration: 0.35 }}
+                    >
+                        <button
+                            className="absolute top-2 right-2 btn btn-xs btn-ghost text-gray-400 hover:text-white"
+                            onClick={onClose}
+                            aria-label="Cerrar"
+                            type="button"
+                        >
+                            <X size={18} />
+                        </button>
+                        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                            <div className="flex items-center justify-center gap-2 mb-2">
+                                <h2 className="text-lg font-semibold text-white">Editar categoría</h2>
+                            </div>
+                            <input
+                                type="text"
+                                className="input input-bordered w-full bg-gray-800/80 text-white rounded-xl"
+                                placeholder="Nombre de la categoría"
+                                value={name}
+                                onChange={e => setName(e.target.value)}
+                                autoFocus
+                                maxLength={32}
+                            />
+                            {error && <span className="text-xs text-pink-400 pl-1">{error}</span>}
+                            <button
+                                type="submit"
+                                className="btn btn-primary w-full rounded-xl mt-2"
+                                disabled={loading}
+                            >
+                                {loading ? "Guardando..." : "Guardar"}
+                            </button>
+                        </form>
+                    </motion.div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}

--- a/frontend/src/pages/Categories/ListCategoryPage.tsx
+++ b/frontend/src/pages/Categories/ListCategoryPage.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { Sparkles, Plus, Pencil, Trash } from "lucide-react";
+import { useCategories } from "../../hooks/useCategories";
+import { useAuth } from "../../context/AuthProvider";
+import { CreateCategoryDialog } from "../../components/categories/CreateCategoryDialog";
+import { EditCategoryDialog } from "../../components/categories/EditCategoryDialog";
+import ConfirmDeleteCategoryDialog from "../../components/categories/ConfirmDeleteCategoryDialog";
+import type { Category } from "../../types/category";
+
+export function ListCategoryPage() {
+    const { user } = useAuth();
+    const { categories, createCategory, updateCategory, deleteCategory, fetchCategories } = useCategories();
+    const [createOpen, setCreateOpen] = useState(false);
+    const [editModal, setEditModal] = useState<{ open: boolean; category: Category | null }>({ open: false, category: null });
+    const [deleteModal, setDeleteModal] = useState<{ open: boolean; id: string | null }>({ open: false, id: null });
+
+    const handleCreate = async (name: string) => {
+        await createCategory({ name, user_id: user?.id });
+        await fetchCategories();
+    };
+
+    const handleEdit = async (name: string) => {
+        if (!editModal.category) return;
+        await updateCategory(editModal.category.id, { name });
+        setEditModal({ open: false, category: null });
+    };
+
+    const handleDelete = async () => {
+        if (!deleteModal.id) return;
+        await deleteCategory(deleteModal.id);
+        setDeleteModal({ open: false, id: null });
+    };
+
+    return (
+        <main className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-950 text-white flex flex-col items-center">
+            <CreateCategoryDialog
+                open={createOpen}
+                onClose={() => setCreateOpen(false)}
+                onCreate={handleCreate}
+            />
+            <EditCategoryDialog
+                open={editModal.open}
+                initialName={editModal.category?.name || ""}
+                onClose={() => setEditModal({ open: false, category: null })}
+                onSave={handleEdit}
+            />
+            <ConfirmDeleteCategoryDialog
+                open={deleteModal.open}
+                onCancel={() => setDeleteModal({ open: false, id: null })}
+                onConfirm={handleDelete}
+            />
+            <section className="w-full max-w-md px-4 py-10 space-y-6">
+                <header className="flex items-center justify-between bg-gray-900/70 rounded-2xl px-6 py-4 shadow-lg border border-gray-800">
+                    <h1 className="text-xl font-semibold">Categorías</h1>
+                    <button
+                        type="button"
+                        onClick={() => setCreateOpen(true)}
+                        className="btn btn-sm btn-primary rounded-lg"
+                    >
+                        <Plus size={16} /> Nueva
+                    </button>
+                </header>
+                {categories.length ? (
+                    <ul className="space-y-3">
+                        {categories.map(c => (
+                            <li key={c.id} className="group flex items-center justify-between bg-gray-900/70 border border-gray-800 rounded-xl p-3 shadow-lg">
+                                <span className="font-medium">{c.name}</span>
+                                <div className="flex gap-3 opacity-80">
+                                    <button
+                                        onClick={() => setEditModal({ open: true, category: c })}
+                                        className="p-1 hover:text-indigo-400"
+                                        title="Editar"
+                                    >
+                                        <Pencil size={18} />
+                                    </button>
+                                    <button
+                                        onClick={() => setDeleteModal({ open: true, id: c.id })}
+                                        className="p-1 hover:text-red-500"
+                                        title="Eliminar"
+                                    >
+                                        <Trash size={18} />
+                                    </button>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="text-center text-gray-400 flex flex-col items-center gap-1">
+                        <Sparkles size={18} /> No se encontraron categorías.
+                    </p>
+                )}
+            </section>
+        </main>
+    );
+}
+
+export default ListCategoryPage;


### PR DESCRIPTION
## Summary
- add a page to list user categories
- include dialogs to create, edit and delete categories
- add route and header link to access categories page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bdcebd7648330838af47ded05aab7