### PR TITLE
Add password recovery flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import { Toaster } from 'react-hot-toast';
 import { PrivateRoute } from './components/PrivateRoute'
 import { LoginPage } from './pages/Auth/LoginPage';
 import { RegisterPage } from './pages/Auth/RegisterPage';
+import { ForgotPasswordPage } from './pages/Auth/ForgotPasswordPage';
+import { ResetPasswordPage } from './pages/Auth/ResetPasswordPage';
 import { HomePage } from './pages/HomePage';
 import { Header } from './components/Header';
 import { ListLinkPage } from './pages/Links/ListLinkPage';
@@ -20,6 +22,8 @@ function AnimatedRoutes() {
                 <Route path="/" element={<HomePage />} />
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/register" element={<RegisterPage />} />
+                <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+                <Route path="/reset-password" element={<ResetPasswordPage />} />
 
                 <Route element={<PrivateRoute />}>
                     <Route path="/links" element={<ListLinkPage />} />

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -9,6 +9,8 @@ type AuthContextType = {
     signIn: (email: string, password: string) => Promise<void>;
     signUp: (email: string, password: string) => Promise<void>;
     signOut: () => Promise<void>;
+    resetPassword: (email: string) => Promise<void>;
+    updatePassword: (password: string) => Promise<void>;
 };
 
 
@@ -46,12 +48,33 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         }
     };
 
+
     const signOut = async () => {
         const { error } = await supabase.auth.signOut();
         if (error) throw error;
     };
 
-    const value = { session, user, signIn, signUp, signOut };
+    const resetPassword = async (email: string) => {
+        const { error } = await supabase.auth.resetPasswordForEmail(email, {
+            redirectTo: `${window.location.origin}/reset-password`,
+        });
+        if (error) throw error;
+    };
+
+    const updatePassword = async (password: string) => {
+        const { error } = await supabase.auth.updateUser({ password });
+        if (error) throw error;
+    };
+
+    const value = {
+        session,
+        user,
+        signIn,
+        signUp,
+        signOut,
+        resetPassword,
+        updatePassword,
+    };
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/frontend/src/pages/Auth/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/Auth/ForgotPasswordPage.tsx
@@ -1,0 +1,62 @@
+import { motion } from "framer-motion";
+import { useState } from "react";
+import { pageVariants, pageTransition } from "../../animations/pageVariants";
+import { useAuth } from "../../context/AuthProvider";
+import { toast } from "react-hot-toast";
+
+export const ForgotPasswordPage = () => {
+    const { resetPassword } = useAuth();
+    const [sent, setSent] = useState(false);
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        const email = e.currentTarget.email.value;
+        try {
+            await resetPassword(email);
+            setSent(true);
+            toast.success("Correo enviado");
+        } catch (err) {
+            console.error(err);
+            toast.error("Error al enviar el correo");
+        }
+    };
+
+    return (
+        <motion.section
+            variants={pageVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            transition={pageTransition}
+            className="h-[calc(100dvh-80px)] flex items-start justify-center pt-24 px-4 bg-gradient-to-br from-gray-900 via-gray-800 to-gray-950"
+        >
+            <motion.form
+                onSubmit={handleSubmit}
+                className="w-full max-w-xs sm:max-w-sm md:max-w-md rounded-2xl bg-gray-800/70 backdrop-blur ring-1 ring-white/10 shadow-xl"
+                initial={{ y: 20, opacity: 0 }}
+                animate={{ y: 0, opacity: 1 }}
+                transition={{ type: "spring", stiffness: 140, damping: 18, delay: 0.15 }}
+            >
+                <div className="p-8 space-y-6">
+                    <h2 className="text-center text-2xl font-semibold text-gray-100">Recuperar contraseña</h2>
+                    {sent ? (
+                        <p className="text-gray-300 text-sm">Revisa tu correo para continuar con el proceso.</p>
+                    ) : (
+                        <>
+                            <input
+                                name="email"
+                                type="email"
+                                required
+                                placeholder="Email"
+                                className="input input-bordered w-full bg-gray-900/50 text-gray-100"
+                            />
+                            <button type="submit" className="btn btn-primary w-full rounded-xl">
+                                Enviar enlace
+                            </button>
+                        </>
+                    )}
+                </div>
+            </motion.form>
+        </motion.section>
+    );
+};

--- a/frontend/src/pages/Auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/Auth/ResetPasswordPage.tsx
@@ -1,28 +1,26 @@
 import { useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
-import { useAuth } from '../../context/AuthProvider';
-import { toast } from 'react-hot-toast';
 import { motion } from "framer-motion";
+import { useNavigate } from "react-router-dom";
 import { pageVariants, pageTransition } from "../../animations/pageVariants";
-import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from "../../context/AuthProvider";
+import { toast } from "react-hot-toast";
 
-export const LoginPage = () => {
-    const { signIn } = useAuth();
+export const ResetPasswordPage = () => {
+    const { updatePassword } = useAuth();
     const navigate = useNavigate();
     const [showPassword, setShowPassword] = useState(false);
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-
-        const email = e.currentTarget.email.value;
-        const pass  = e.currentTarget.password.value;
-
+        const pass = e.currentTarget.password.value;
         try {
-            await signIn(email, pass);
-            navigate('/links');
+            await updatePassword(pass);
+            toast.success("Contraseña actualizada");
+            navigate("/links");
         } catch (err) {
             console.error(err);
-            toast.error('Credenciales incorrectas');
+            toast.error("Error al actualizar la contraseña");
         }
     };
 
@@ -33,26 +31,17 @@ export const LoginPage = () => {
             animate="animate"
             exit="exit"
             transition={pageTransition}
-            className='h-[calc(100dvh-80px)] flex items-start justify-center pt-24 px-4 bg-gradient-to-br from-gray-900 via-gray-800 to-gray-950'
+            className="h-[calc(100dvh-80px)] flex items-start justify-center pt-24 px-4 bg-gradient-to-br from-gray-900 via-gray-800 to-gray-950"
         >
             <motion.form
                 onSubmit={handleSubmit}
-                className="w-full max-w-xs sm:max-w-sm md:max-w-md rounded-2xl bg-gray-800/70 backdrop-blur
-                   ring-1 ring-white/10 shadow-xl"
+                className="w-full max-w-xs sm:max-w-sm md:max-w-md rounded-2xl bg-gray-800/70 backdrop-blur ring-1 ring-white/10 shadow-xl"
                 initial={{ y: 20, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ type: "spring", stiffness: 140, damping: 18, delay: 0.15 }}
             >
                 <div className="p-8 space-y-6">
-                    <h2 className="text-center text-2xl font-semibold text-gray-100">Inicia sesión</h2>
-
-                    <input
-                        name="email"
-                        type="email"
-                        required
-                        placeholder="Email"
-                        className="input input-bordered w-full bg-gray-900/50 text-gray-100"
-                    />
+                    <h2 className="text-center text-2xl font-semibold text-gray-100">Nueva contraseña</h2>
                     <div className="relative">
                         <input
                             name="password"
@@ -70,21 +59,9 @@ export const LoginPage = () => {
                             {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
                         </button>
                     </div>
-
                     <button type="submit" className="btn btn-primary w-full rounded-xl">
-                        Entrar
+                        Actualizar
                     </button>
-                    <p className="text-center text-sm text-gray-400">
-                        <Link to="/forgot-password" className="text-indigo-300 hover:underline">
-                            ¿Olvidaste tu contraseña?
-                        </Link>
-                    </p>
-                    <p className="text-center text-sm text-gray-400">
-                        ¿No tienes cuenta?{' '}
-                        <Link to="/register" className="text-indigo-300 hover:underline">
-                            Regístrate
-                        </Link>
-                    </p>
                 </div>
             </motion.form>
         </motion.section>


### PR DESCRIPTION
## Summary
- implement password reset helpers in `AuthProvider`
- add ForgotPasswordPage and ResetPasswordPage
- update routes and login page link for recovery

## Testing
- `npx vitest run` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686d30bae2bc833099dbc2c3cd09ab0e