### PR TITLE
feat: add usage analytics

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { ListLinkPage } from './pages/Links/ListLinkPage';
 import { CreateLinkPage } from './pages/Links/CreateLinkPage';
 import EditLinkPage from './pages/Links/EditLinkPage';
 import ListCategoryPage from './pages/Categories/ListCategoryPage';
+import { UsagePage } from './pages/UsagePage';
 import { AnimatePresence } from "framer-motion";
 import { PrivacyPolicyPage } from './pages/PrivacyPolicyPage';
 import { Footer } from './components/Footer.tsx';
@@ -29,6 +30,7 @@ function AnimatedRoutes() {
                     <Route path="/links/new" element={<CreateLinkPage />} />
                     <Route path="/links/:id/edit" element={<EditLinkPage />} />
                     <Route path="/categories" element={<ListCategoryPage />} />
+                    <Route path="/usage" element={<UsagePage />} />
                 </Route>
 
                 <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -63,6 +63,17 @@ export function Header() {
                             </NavLink>
 
                             <NavLink
+                                to="/usage"
+                                className={({ isActive }) =>
+                                    isActive
+                                        ? "font-semibold text-indigo-300"
+                                        : "text-gray-300 hover:text-indigo-200 transition-colors"
+                                }
+                            >
+                                {t('nav.usage')}
+                            </NavLink>
+
+                            <NavLink
                                 to="/links/new"
                                 className={({ isActive }) =>
                                     isActive
@@ -157,6 +168,17 @@ export function Header() {
                             }
                         >
                             {t('nav.categories')}
+                        </NavLink>
+                        <NavLink
+                            to="/usage"
+                            onClick={() => setMenuOpen(false)}
+                            className={({ isActive }) =>
+                                isActive
+                                    ? 'font-semibold text-indigo-300'
+                                    : 'text-gray-300 hover:text-indigo-200 transition-colors'
+                            }
+                        >
+                            {t('nav.usage')}
                         </NavLink>
                         <NavLink
                             to="/links/new"

--- a/frontend/src/components/links/LinkCard.tsx
+++ b/frontend/src/components/links/LinkCard.tsx
@@ -3,12 +3,13 @@ import { useMemo } from "react";
 import { gradientColors } from "../../constants/gradientColors";
 import SocialIcon from "./SocialIcon";
 import { useTranslation } from "react-i18next";
+import { trackOpen } from "../../lib/analytics.service";
 
 function getRandomGradient() {
     return gradientColors[Math.floor(Math.random() * gradientColors.length)];
 }
 
-function LinkCard({ link }: { link: Link }) {
+function LinkCard({ link, onOpen }: { link: Link; onOpen?: () => void }) {
     const { t } = useTranslation();
     
     const tagGradients = useMemo(
@@ -20,7 +21,16 @@ function LinkCard({ link }: { link: Link }) {
         <article className="flex items-start gap-3 p-4 rounded-xl shadow-sm">
             <SocialIcon url={link.url} />
             <div className="flex-1">
-                <a href={link.url} target="_blank" rel="noreferrer" className="font-semibold">
+                <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-semibold"
+                    onClick={() => {
+                        trackOpen(link.id).catch(console.error);
+                        onOpen?.();
+                    }}
+                >
                     {link.title ? link.title : link.url}
                 </a>
                 <p className="text-sm text-gray-500">{link.description}</p>

--- a/frontend/src/lib/analytics.service.test.ts
+++ b/frontend/src/lib/analytics.service.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { trackOpen, getUsageSummary } from './analytics.service';
+
+vi.mock('./supabase', () => ({
+    supabase: {
+        rpc: vi.fn().mockResolvedValue({ data: null, error: null })
+    }
+}));
+
+describe('analytics.service', () => {
+    it('calls track_open rpc', async () => {
+        const { supabase } = await import('./supabase');
+        await trackOpen('123');
+        expect(supabase.rpc).toHaveBeenCalledWith('track_open', { _link_id: '123' });
+    });
+
+    it('calls get_usage_summary rpc', async () => {
+        const { supabase } = await import('./supabase');
+        await getUsageSummary({ from: '2024-01-01', to: '2024-01-31' });
+        expect(supabase.rpc).toHaveBeenCalledWith('get_usage_summary', { _from: '2024-01-01', _to: '2024-01-31' });
+    });
+});

--- a/frontend/src/lib/analytics.service.ts
+++ b/frontend/src/lib/analytics.service.ts
@@ -1,0 +1,14 @@
+import { supabase } from './supabase';
+
+export async function trackOpen(linkId: string) {
+    return supabase.rpc('track_open', { _link_id: linkId });
+}
+
+export interface UsageSummaryParams {
+    from: string;
+    to: string;
+}
+
+export async function getUsageSummary(params: UsageSummaryParams) {
+    return supabase.rpc('get_usage_summary', { _from: params.from, _to: params.to });
+}

--- a/frontend/src/lib/dateRange.test.ts
+++ b/frontend/src/lib/dateRange.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getPresetRange } from './dateRange';
+
+describe('getPresetRange', () => {
+    it('returns last 7 days range', () => {
+        vi.setSystemTime(new Date('2024-01-10T00:00:00Z'));
+        const { from, to } = getPresetRange('7d');
+        expect(to.toISOString()).toBe(new Date('2024-01-10T00:00:00Z').toISOString());
+        expect(from.toISOString()).toBe(new Date('2024-01-03T00:00:00.000Z').toISOString());
+    });
+});

--- a/frontend/src/lib/dateRange.ts
+++ b/frontend/src/lib/dateRange.ts
@@ -1,0 +1,23 @@
+export type Preset = 'today' | '7d' | '30d';
+
+function startOfDay(d: Date) {
+    const dt = new Date(d);
+    dt.setHours(0, 0, 0, 0);
+    return dt;
+}
+
+export function getPresetRange(preset: Preset) {
+    const now = new Date();
+    const to = now;
+    let from = new Date(now);
+    if (preset === 'today') {
+        from = startOfDay(now);
+    }
+    if (preset === '7d') {
+        from.setDate(now.getDate() - 7);
+    }
+    if (preset === '30d') {
+        from.setDate(now.getDate() - 30);
+    }
+    return { from, to };
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -48,6 +48,7 @@
         "links": "My links",
         "categories": "My categories",
         "addLink": "Add link",
+        "usage": "Usage",
         "openMenu": "Open menu",
         "closeMenu": "Close menu"
     },
@@ -194,5 +195,18 @@
             "You can request the deletion of your data at any time by contacting us.",
             "If you have questions about how we handle your information, please write to mailslinknest@gmail.com."
         ]
+    }
+    ,
+    "usage": {
+        "total": "Total links",
+        "top": "Top visited",
+        "never": "Never opened",
+        "filter": {
+            "range": "Date range",
+            "today": "Today",
+            "7d": "Last 7 days",
+            "30d": "Last 30 days",
+            "custom": "Custom"
+        }
     }
 }

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -48,6 +48,7 @@
         "links": "Mis enlaces",
         "categories": "Mis categorías",
         "addLink": "Añadir enlace",
+        "usage": "Uso",
         "openMenu": "Abrir menú",
         "closeMenu": "Cerrar menú"
     },
@@ -194,5 +195,17 @@
             "Puedes solicitar la eliminación de tus datos en cualquier momento contactándonos.",
             "Si tienes preguntas sobre cómo manejamos tu información, escríbenos a mailslinknest@gmail.com."
         ]
+    },
+    "usage": {
+        "total": "Total de enlaces",
+        "top": "Más visitados",
+        "never": "Nunca abiertos",
+        "filter": {
+            "range": "Rango de fechas",
+            "today": "Hoy",
+            "7d": "7 días",
+            "30d": "30 días",
+            "custom": "Personalizado"
+        }
     }
 }

--- a/frontend/src/pages/UsagePage.tsx
+++ b/frontend/src/pages/UsagePage.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import LinkCard from '../components/links/LinkCard';
+import { getUsageSummary } from '../lib/analytics.service';
+import { getPresetRange, Preset } from '../lib/dateRange';
+
+interface Summary {
+    total_links: number;
+    top_links: { id: string; title: string; url: string; open_count: number }[];
+    never_opened: { id: string; title: string; url: string }[];
+}
+
+export function UsagePage() {
+    const { t } = useTranslation();
+    const [preset, setPreset] = useState<Preset | 'custom'>('7d');
+    const [range, setRange] = useState(() => getPresetRange('7d'));
+    const [customFrom, setCustomFrom] = useState('');
+    const [customTo, setCustomTo] = useState('');
+    const [summary, setSummary] = useState<Summary | null>(null);
+
+    useEffect(() => {
+        const load = async () => {
+            const { data } = await getUsageSummary({ from: range.from.toISOString(), to: range.to.toISOString() });
+            setSummary(data);
+        };
+        load();
+    }, [range]);
+
+    const handlePreset = (p: Preset | 'custom') => {
+        setPreset(p);
+        if (p === 'custom') return;
+        const r = getPresetRange(p);
+        setRange(r);
+    };
+
+    const handleCustomChange = (f: string, t: string) => {
+        setCustomFrom(f);
+        setCustomTo(t);
+        if (f && t) {
+            setRange({ from: new Date(f), to: new Date(t) });
+        }
+    };
+
+    const handleOpened = (id: string) => {
+        setSummary(s =>
+            s
+                ? {
+                      ...s,
+                      never_opened: s.never_opened.filter(l => l.id !== id),
+                  }
+                : s
+        );
+    };
+
+    return (
+        <main className="p-4 text-white">
+            <section className="mb-4">
+                <label className="mr-2">{t('usage.filter.range')}</label>
+                <select
+                    value={preset}
+                    onChange={e => handlePreset(e.target.value as Preset | 'custom')}
+                    className="text-black"
+                >
+                    <option value="today">{t('usage.filter.today')}</option>
+                    <option value="7d">{t('usage.filter.7d')}</option>
+                    <option value="30d">{t('usage.filter.30d')}</option>
+                    <option value="custom">{t('usage.filter.custom')}</option>
+                </select>
+                {preset === 'custom' && (
+                    <span className="ml-2">
+                        <input
+                            type="date"
+                            value={customFrom}
+                            onChange={e => handleCustomChange(e.target.value, customTo)}
+                            className="text-black mr-1"
+                        />
+                        <input
+                            type="date"
+                            value={customTo}
+                            onChange={e => handleCustomChange(customFrom, e.target.value)}
+                            className="text-black"
+                        />
+                    </span>
+                )}
+            </section>
+
+            {summary && (
+                <section className="space-y-6">
+                    <div>
+                        <h2 className="text-xl font-bold">{t('usage.total')}</h2>
+                        <p>{summary.total_links}</p>
+                    </div>
+                    <div>
+                        <h2 className="text-xl font-bold">{t('usage.top')}</h2>
+                        <ul className="space-y-2">
+                            {summary.top_links.map(l => (
+                                <li key={l.id} className="border p-2 rounded">
+                                    <a
+                                        href={l.url}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="underline"
+                                    >
+                                        {l.title}
+                                    </a>
+                                    {' '}- {l.open_count}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                    <div>
+                        <h2 className="text-xl font-bold">{t('usage.never')}</h2>
+                        <ul className="space-y-2">
+                            {summary.never_opened.map(l => (
+                                <li key={l.id} className="border p-2 rounded">
+                                    <LinkCard link={{ id: l.id, url: l.url, title: l.title }} onOpen={() => handleOpened(l.id)} />
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </section>
+            )}
+        </main>
+    );
+}
+
+export default UsagePage;

--- a/frontend/tests/e2e/usage.spec.ts
+++ b/frontend/tests/e2e/usage.spec.ts
@@ -1,0 +1,5 @@
+import { test } from 'playwright/test';
+
+test.skip('open link updates usage stats', () => {
+    // Requires authenticated session and backend; skipped in CI environment.
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
-        exclude: ['tests/e2e/**'],
+        exclude: ['node_modules/**', 'dist/**', 'tests/e2e/**'],
         environment: 'jsdom'
     }
 });

--- a/supabase/migrations/20240518000000_usage_stats.sql
+++ b/supabase/migrations/20240518000000_usage_stats.sql
@@ -1,0 +1,104 @@
+-- Link events tracking
+
+create table if not exists public.link_events (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    link_id uuid not null references public.links(id) on delete cascade,
+    event_type text not null check (event_type = 'open'),
+    created_at timestamptz not null default now()
+);
+
+-- indexes for performance
+create index if not exists link_events_user_created_at_idx on public.link_events(user_id, created_at);
+create index if not exists link_events_user_link_idx on public.link_events(user_id, link_id);
+
+-- optional quick access fields in links
+alter table public.links add column if not exists open_count int default 0;
+alter table public.links add column if not exists last_opened_at timestamptz;
+
+-- row level security
+alter table public.link_events enable row level security;
+create policy if not exists "link_events_select" on public.link_events
+    for select using (auth.uid() = user_id);
+create policy if not exists "link_events_insert" on public.link_events
+    for insert with check (auth.uid() = user_id);
+
+alter table public.links enable row level security;
+create policy if not exists "links_owner" on public.links
+    using (auth.uid() = user_id)
+    with check (auth.uid() = user_id);
+
+-- function to track link openings
+create or replace function public.track_open(_link_id uuid)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+    insert into public.link_events(user_id, link_id, event_type)
+    values (auth.uid(), _link_id, 'open');
+
+    update public.links
+    set open_count = coalesce(open_count, 0) + 1,
+        last_opened_at = now()
+    where id = _link_id
+      and user_id = auth.uid();
+end;
+$$;
+
+grant execute on function public.track_open(uuid) to authenticated;
+
+-- function to get usage summary
+create or replace function public.get_usage_summary(_from timestamptz, _to timestamptz)
+returns table (
+    total_links bigint,
+    top_links jsonb,
+    never_opened jsonb
+)
+language plpgsql
+security definer
+as $$
+declare
+    top jsonb;
+    never jsonb;
+begin
+    select count(*)
+    into total_links
+    from public.links
+    where user_id = auth.uid();
+
+    top := (
+        select coalesce(jsonb_agg(t), '[]'::jsonb)
+        from (
+            select l.id, l.title, l.url, count(e.id) as open_count
+            from public.links l
+            join public.link_events e on e.link_id = l.id
+            where l.user_id = auth.uid()
+              and e.user_id = auth.uid()
+              and e.created_at between _from and _to
+            group by l.id, l.title
+            order by count(e.id) desc
+            limit 5
+        ) t
+    );
+
+    never := (
+        select coalesce(jsonb_agg(t), '[]'::jsonb)
+        from (
+            select l.id, l.title, l.url
+            from public.links l
+            left join public.link_events e
+              on e.link_id = l.id
+             and e.user_id = auth.uid()
+             and e.created_at between _from and _to
+            where l.user_id = auth.uid() and e.id is null
+        ) t
+    );
+
+    top_links := top;
+    never_opened := never;
+    return next;
+end;
+$$;
+
+grant execute on function public.get_usage_summary(timestamptz, timestamptz) to authenticated;

--- a/supabase/tests/usage_stats.test.sql
+++ b/supabase/tests/usage_stats.test.sql
@@ -1,0 +1,7 @@
+begin;
+select plan(3);
+select has_table('public', 'link_events');
+select has_function('public', 'track_open');
+select has_function('public', 'get_usage_summary');
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- track link openings and query usage summary
- add usage page with date filters and stats
- include SQL migration and RLS policies

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: TypeError Cannot redefine property: Symbol($$jest-matchers-object))*

------
https://chatgpt.com/codex/tasks/task_e_68a70bd4a548833097bf7e73555eb7ad