### PR TITLE
Improve privacy policy copy

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -189,12 +189,13 @@
     "privacy": {
         "title": "Privacy Policy",
         "paragraphs": [
-            "LinkNest only uses the data necessary to provide the service.",
-            "We do not share your information with third parties without your consent.",
-            "Usage data is collected anonymously to improve the application.",
-            "Cookies are used only for authentication and storing your preferences.",
-            "You can request the deletion of your data at any time by contacting us.",
-            "If you have questions about how we handle your information, please write to mailslinknest@gmail.com."
+            "At LinkNest we handle your personal data transparently and in accordance with Regulation (EU) 2016/679 (GDPR) and applicable local laws.",
+            "We only collect the information needed to create your account and deliver the service, such as your email address, saved links, tags, notes, and preferences.",
+            "We use this data to manage your link space, sync your content across devices, improve the product, and respond to support requests.",
+            "We do not sell your data or share it with third parties for commercial purposes; we only work with service providers that help us run the platform (hosting, aggregated analytics, authentication) under confidentiality obligations.",
+            "We retain your information while your account remains active; you can request deletion or portability of your data at any time, and we will also purge backups within reasonable technical timelines.",
+            "Cookies and similar technologies are used solely to secure your sessions, remember your preferences, and analyze how LinkNest is used in aggregate, without tracking you outside the service.",
+            "If you need more details or wish to exercise your access, rectification, erasure, or objection rights, contact us at mailslinknest@gmail.com and we will assist you."
         ]
     }
     ,

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -189,12 +189,13 @@
     "privacy": {
         "title": "Política de privacidad",
         "paragraphs": [
-            "LinkNest solo utiliza los datos necesarios para ofrecer el servicio.",
-            "No compartimos tu información con terceros sin tu consentimiento.",
-            "Los datos de uso se recopilan de forma anónima para mejorar la aplicación.",
-            "Usamos cookies únicamente para la autenticación y almacenar tus preferencias.",
-            "Puedes solicitar la eliminación de tus datos en cualquier momento contactándonos.",
-            "Si tienes preguntas sobre cómo manejamos tu información, escríbenos a mailslinknest@gmail.com."
+            "En LinkNest tratamos tus datos personales con transparencia y de acuerdo con el Reglamento (UE) 2016/679 (RGPD) y la legislación local aplicable.",
+            "Recogemos únicamente la información necesaria para crear tu cuenta y prestar el servicio, como tu correo electrónico, enlaces guardados, etiquetas, notas y preferencias.",
+            "Utilizamos estos datos para gestionar tu espacio de enlaces, sincronizar tus contenidos entre dispositivos, mejorar el producto y responder a tus solicitudes de soporte.",
+            "No vendemos tus datos ni los compartimos con terceros para fines comerciales; solo trabajamos con proveedores que nos ayudan a operar la plataforma (alojamiento, analítica agregada, autenticación) y que actúan siguiendo nuestras instrucciones y compromisos de confidencialidad.",
+            "Conservamos tu información mientras mantienes activa la cuenta; puedes solicitar la eliminación o portabilidad de tus datos en cualquier momento y eliminaremos también las copias de seguridad en los plazos técnicos razonables.",
+            "Las cookies y tecnologías similares se usan exclusivamente para iniciar sesión de forma segura, recordar tus preferencias y analizar de forma agregada cómo se utiliza LinkNest, sin rastrearte fuera del servicio.",
+            "Si necesitas más información o ejercer tus derechos de acceso, rectificación, cancelación u oposición, escríbenos a mailslinknest@gmail.com y atenderemos tu consulta."
         ]
     },
     "usage": {


### PR DESCRIPTION
## Summary
- expand the Spanish privacy policy copy with clearer details on data handling, retention, and user rights
- mirror the improved privacy policy language in the English locale file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd4ae1607483308b43feb62f938ac2