### PR TITLE
Enhance privacy policy layout

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -188,17 +188,73 @@
     },
     "privacy": {
         "title": "Privacy Policy",
-        "paragraphs": [
-            "At LinkNest we handle your personal data transparently and in accordance with Regulation (EU) 2016/679 (GDPR) and applicable local laws.",
-            "We only collect the information needed to create your account and deliver the service, such as your email address, saved links, tags, notes, and preferences.",
-            "We use this data to manage your link space, sync your content across devices, improve the product, and respond to support requests.",
-            "We do not sell your data or share it with third parties for commercial purposes; we only work with service providers that help us run the platform (hosting, aggregated analytics, authentication) under confidentiality obligations.",
-            "We retain your information while your account remains active; you can request deletion or portability of your data at any time, and we will also purge backups within reasonable technical timelines.",
-            "Cookies and similar technologies are used solely to secure your sessions, remember your preferences, and analyze how LinkNest is used in aggregate, without tracking you outside the service.",
-            "If you need more details or wish to exercise your access, rectification, erasure, or objection rights, contact us at mailslinknest@gmail.com and we will assist you."
-        ]
-    }
-    ,
+        "badge": "Your data, always yours",
+        "lastUpdated": "Last updated: 5 February 2025",
+        "intro": "We designed LinkNest to be a calm and private space for your saved knowledge. We comply with the GDPR and applicable local regulations and explain in plain language how your information is used.",
+        "cards": [
+            {
+                "icon": "shield",
+                "title": "Transparent by default",
+                "description": "We follow strict privacy principles, document every process and keep you informed about what happens with your personal data."
+            },
+            {
+                "icon": "lock",
+                "title": "Security-first infrastructure",
+                "description": "All connections are encrypted, access is limited to authorised staff, and our partners sign confidentiality agreements."
+            },
+            {
+                "icon": "database",
+                "title": "Minimal retention",
+                "description": "We only keep information while you have an active account and remove backups on a rolling technical schedule."
+            }
+        ],
+        "sections": [
+            {
+                "title": "Data we collect",
+                "description": "We only ask for the essentials to run LinkNest smoothly:",
+                "items": [
+                    "Email address to identify your account and send important communications.",
+                    "Saved links, tags, notes and personal preferences you add inside the product.",
+                    "Technical logs that help us secure sessions, prevent abuse and troubleshoot issues."
+                ]
+            },
+            {
+                "title": "How we use it",
+                "description": "Your information powers the product experience you expect:",
+                "items": [
+                    "Organise and synchronise your collections across devices in real time.",
+                    "Improve existing features and build new ones using aggregated usage metrics.",
+                    "Provide responsive support whenever you contact us and keep you informed about relevant changes.",
+                    "Cookies and similar technologies remember your preferences, secure the account and measure anonymous usage trends."
+                ]
+            },
+            {
+                "title": "When we share information",
+                "description": "We only collaborate with trusted vendors that help us keep LinkNest available:",
+                "items": [
+                    "Infrastructure, storage and email providers that process data strictly under our instructions.",
+                    "Analytics partners that deliver anonymised insights and are prohibited from selling or repurposing your personal data.",
+                    "Legal or compliance disclosures when we are required to do so by law, after verifying the request."
+                ]
+            }
+        ],
+        "rights": {
+            "title": "You are always in control",
+            "description": "At any moment you can exercise your data protection rights:",
+            "items": [
+                "Access and request a copy of the information we store about you.",
+                "Rectify inaccurate details or update your profile whenever you need.",
+                "Request deletion or portability and we will wipe active systems and backups within technical limits.",
+                "Object to certain processing activities such as direct communications or analytics."
+            ]
+        },
+        "contact": {
+            "title": "Need to talk to us?",
+            "description": "We respond to privacy queries within 72 hours. Tell us how we can help and we will work with you closely.",
+            "cta": "Email the privacy team",
+            "email": "mailslinknest@gmail.com"
+        }
+    },
     "usage": {
         "total": "Total links",
         "top": "Top visited",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -188,15 +188,72 @@
     },
     "privacy": {
         "title": "Política de privacidad",
-        "paragraphs": [
-            "En LinkNest tratamos tus datos personales con transparencia y de acuerdo con el Reglamento (UE) 2016/679 (RGPD) y la legislación local aplicable.",
-            "Recogemos únicamente la información necesaria para crear tu cuenta y prestar el servicio, como tu correo electrónico, enlaces guardados, etiquetas, notas y preferencias.",
-            "Utilizamos estos datos para gestionar tu espacio de enlaces, sincronizar tus contenidos entre dispositivos, mejorar el producto y responder a tus solicitudes de soporte.",
-            "No vendemos tus datos ni los compartimos con terceros para fines comerciales; solo trabajamos con proveedores que nos ayudan a operar la plataforma (alojamiento, analítica agregada, autenticación) y que actúan siguiendo nuestras instrucciones y compromisos de confidencialidad.",
-            "Conservamos tu información mientras mantienes activa la cuenta; puedes solicitar la eliminación o portabilidad de tus datos en cualquier momento y eliminaremos también las copias de seguridad en los plazos técnicos razonables.",
-            "Las cookies y tecnologías similares se usan exclusivamente para iniciar sesión de forma segura, recordar tus preferencias y analizar de forma agregada cómo se utiliza LinkNest, sin rastrearte fuera del servicio.",
-            "Si necesitas más información o ejercer tus derechos de acceso, rectificación, cancelación u oposición, escríbenos a mailslinknest@gmail.com y atenderemos tu consulta."
-        ]
+        "badge": "Tus datos siempre son tuyos",
+        "lastUpdated": "Última actualización: 5 de febrero de 2025",
+        "intro": "Creamos LinkNest como un espacio tranquilo y privado para guardar lo que aprendes. Cumplimos con el RGPD y la normativa local aplicable y explicamos con claridad cómo usamos tu información.",
+        "cards": [
+            {
+                "icon": "shield",
+                "title": "Transparencia por defecto",
+                "description": "Seguimos principios estrictos de privacidad, documentamos cada proceso y te mantenemos informado sobre lo que ocurre con tus datos personales."
+            },
+            {
+                "icon": "lock",
+                "title": "Infraestructura segura",
+                "description": "Todas las conexiones están cifradas, el acceso se limita al personal autorizado y nuestros proveedores firman compromisos de confidencialidad."
+            },
+            {
+                "icon": "database",
+                "title": "Retención mínima",
+                "description": "Conservamos la información solo mientras tu cuenta está activa y depuramos las copias de seguridad de forma periódica."
+            }
+        ],
+        "sections": [
+            {
+                "title": "Datos que recopilamos",
+                "description": "Solo solicitamos lo imprescindible para que LinkNest funcione:",
+                "items": [
+                    "Correo electrónico para identificar tu cuenta y enviarte comunicaciones importantes.",
+                    "Enlaces guardados, etiquetas, notas y preferencias personales que añades dentro del producto.",
+                    "Registros técnicos que nos ayudan a proteger las sesiones, prevenir abusos y resolver incidencias."
+                ]
+            },
+            {
+                "title": "Cómo los utilizamos",
+                "description": "Tu información hace posible la experiencia que esperas:",
+                "items": [
+                    "Organizar y sincronizar tus colecciones entre dispositivos en tiempo real.",
+                    "Mejorar las funcionalidades existentes y crear otras nuevas a partir de métricas agregadas.",
+                    "Atender tus solicitudes de soporte y mantenerte al tanto de cambios relevantes.",
+                    "Las cookies y tecnologías similares recuerdan tus preferencias, protegen la cuenta y miden tendencias de uso anónimas."
+                ]
+            },
+            {
+                "title": "Cuándo compartimos información",
+                "description": "Solo colaboramos con proveedores de confianza que nos ayudan a mantener LinkNest disponible:",
+                "items": [
+                    "Servicios de infraestructura, almacenamiento y correo que procesan datos únicamente siguiendo nuestras instrucciones.",
+                    "Socios de analítica que entregan información anonimizada y tienen prohibido vender o reutilizar tus datos personales.",
+                    "Requerimientos legales o de cumplimiento cuando la ley nos obliga y tras verificar la solicitud."
+                ]
+            }
+        ],
+        "rights": {
+            "title": "Siempre tienes el control",
+            "description": "En cualquier momento puedes ejercer tus derechos de protección de datos:",
+            "items": [
+                "Acceder y solicitar una copia de la información que almacenamos sobre ti.",
+                "Rectificar datos inexactos o actualizar tu perfil cuando lo necesites.",
+                "Solicitar la eliminación o portabilidad y eliminaremos los sistemas activos y las copias de seguridad dentro de los límites técnicos.",
+                "Oponerte a determinados tratamientos, como comunicaciones directas o analíticas."
+            ]
+        },
+        "contact": {
+            "title": "¿Necesitas hablar con nosotros?",
+            "description": "Respondemos las consultas de privacidad en menos de 72 horas. Cuéntanos cómo podemos ayudarte y lo haremos contigo.",
+            "cta": "Escríbenos al equipo de privacidad",
+            "email": "mailslinknest@gmail.com"
+        }
     },
     "usage": {
         "total": "Total de enlaces",

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -1,10 +1,59 @@
 import { motion } from "framer-motion";
+import type { LucideIcon } from "lucide-react";
+import { ArrowUpRight, CheckCircle2, Clock, Database, Lock, Mail, ShieldCheck, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { pageVariants, pageTransition } from "../animations/pageVariants";
 
+type PrivacyCard = {
+    icon: string;
+    title: string;
+    description: string;
+};
+
+type PrivacySection = {
+    title: string;
+    description: string;
+    items: string[];
+};
+
+type PrivacyRights = {
+    title: string;
+    description: string;
+    items: string[];
+};
+
+type PrivacyContact = {
+    title: string;
+    description: string;
+    cta: string;
+    email: string;
+};
+
+const iconMap: Record<string, LucideIcon> = {
+    shield: ShieldCheck,
+    lock: Lock,
+    database: Database,
+};
+
 export function PrivacyPolicyPage() {
     const { t } = useTranslation();
-    const paragraphs = t("privacy.paragraphs", { returnObjects: true }) as string[];
+    const rawCards = t("privacy.cards", { returnObjects: true });
+    const rawSections = t("privacy.sections", { returnObjects: true });
+    const rawRights = t("privacy.rights", { returnObjects: true });
+    const rawContact = t("privacy.contact", { returnObjects: true });
+
+    const cards = Array.isArray(rawCards) ? (rawCards as PrivacyCard[]) : [];
+    const sections = Array.isArray(rawSections) ? (rawSections as PrivacySection[]) : [];
+    const rights =
+        rawRights && typeof rawRights === "object"
+            ? (rawRights as PrivacyRights)
+            : { title: "", description: "", items: [] };
+    const contact =
+        rawContact && typeof rawContact === "object"
+            ? (rawContact as PrivacyContact)
+            : { title: "", description: "", cta: "", email: "" };
+
+    const rightsItems = Array.isArray(rights.items) ? rights.items : [];
 
     return (
         <motion.section
@@ -13,19 +62,113 @@ export function PrivacyPolicyPage() {
             animate="animate"
             exit="exit"
             transition={pageTransition}
-            className="min-h-[calc(100dvh-80px)] flex items-start justify-center pt-16 px-4 bg-gradient-to-br from-gray-900 via-gray-800 to-gray-950"
+            className="relative min-h-[calc(100dvh-80px)] overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-4 pb-20 pt-16"
         >
+            <div className="absolute inset-0 -z-10">
+                <div className="absolute -left-24 top-16 h-72 w-72 rounded-full bg-violet-500/25 blur-3xl" aria-hidden />
+                <div className="absolute bottom-0 right-0 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" aria-hidden />
+            </div>
+
             <motion.article
                 initial={{ y: 20, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ type: "spring", stiffness: 140, damping: 18, delay: 0.15 }}
-                className="w-full max-w-3xl rounded-2xl bg-gray-900/80 backdrop-blur border border-gray-800 p-8 shadow-lg text-gray-300"
+                className="relative mx-auto flex w-full max-w-5xl flex-col gap-10 rounded-[32px] border border-white/10 bg-white/5 p-8 text-slate-200 shadow-2xl backdrop-blur-xl md:p-10"
             >
-                <h1 className="text-3xl font-bold mb-6 text-gray-100">{t("privacy.title")}</h1>
-                <div className="space-y-4 text-sm leading-relaxed">
-                    {paragraphs.map((p, idx) => (
-                        <p key={idx}>{p}</p>
+                <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-8 md:p-10">
+                    <div
+                        className="absolute inset-x-0 -top-40 h-80 bg-gradient-to-b from-violet-500/25 via-violet-500/10 to-transparent blur-3xl"
+                        aria-hidden
+                    />
+                    <div className="relative space-y-6">
+                        <span className="inline-flex items-center gap-2 rounded-full border border-violet-400/30 bg-violet-500/10 px-4 py-1 text-xs font-medium uppercase tracking-[0.3em] text-violet-200">
+                            <Sparkles className="h-4 w-4" aria-hidden />
+                            {t("privacy.badge")}
+                        </span>
+                        <div className="space-y-4">
+                            <h1 className="text-3xl font-bold text-slate-50 md:text-4xl">{t("privacy.title")}</h1>
+                            <p className="text-base leading-relaxed text-slate-300 md:text-lg">{t("privacy.intro")}</p>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-3 text-sm text-slate-400">
+                            <div className="flex items-center gap-2 rounded-full bg-slate-800/60 px-3 py-1.5">
+                                <Clock className="h-4 w-4" aria-hidden />
+                                <span>{t("privacy.lastUpdated")}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-3">
+                    {cards.map((card, idx) => {
+                        const Icon = iconMap[card.icon] ?? ShieldCheck;
+
+                        return (
+                            <div
+                                key={`${card.title}-${idx}`}
+                                className="group relative overflow-hidden rounded-2xl border border-slate-700/60 bg-slate-900/70 p-6 shadow-lg transition hover:border-violet-400/60 hover:bg-slate-900"
+                            >
+                                <span className="mb-5 inline-flex h-12 w-12 items-center justify-center rounded-full bg-violet-500/15 text-violet-200 ring-1 ring-inset ring-violet-400/40">
+                                    <Icon className="h-6 w-6" aria-hidden />
+                                </span>
+                                <h2 className="text-lg font-semibold text-slate-100">{card.title}</h2>
+                                <p className="mt-2 text-sm leading-relaxed text-slate-300">{card.description}</p>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <div className="grid gap-6">
+                    {sections.map((section, idx) => (
+                        <div
+                            key={`${section.title}-${idx}`}
+                            className="rounded-3xl border border-slate-700/60 bg-slate-900/60 p-6 shadow-lg md:p-8"
+                        >
+                            <h3 className="text-xl font-semibold text-slate-100">{section.title}</h3>
+                            <p className="mt-2 text-sm text-slate-300">{section.description}</p>
+                            <ul className="mt-4 space-y-3">
+                                {section.items.map((item, itemIdx) => (
+                                    <li key={`${section.title}-${itemIdx}`} className="flex items-start gap-3 text-sm text-slate-200">
+                                        <CheckCircle2 className="mt-1 h-4 w-4 flex-shrink-0 text-violet-300" aria-hidden />
+                                        <span className="leading-relaxed text-slate-300">{item}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
                     ))}
+                </div>
+
+                <div className="grid gap-6 md:grid-cols-[2fr,1fr]">
+                    <div className="rounded-3xl border border-slate-700/60 bg-slate-900/60 p-6 shadow-lg md:p-8">
+                        <h3 className="text-xl font-semibold text-slate-100">{rights.title}</h3>
+                        <p className="mt-2 text-sm text-slate-300">{rights.description}</p>
+                        <ul className="mt-4 space-y-3">
+                            {rightsItems.map((item, idx) => (
+                                <li key={`right-${idx}`} className="flex items-start gap-3 text-sm text-slate-200">
+                                    <CheckCircle2 className="mt-1 h-4 w-4 flex-shrink-0 text-emerald-300" aria-hidden />
+                                    <span className="leading-relaxed text-slate-300">{item}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="relative overflow-hidden rounded-3xl border border-violet-400/30 bg-gradient-to-br from-violet-500/20 via-slate-900 to-slate-950 p-6 text-slate-100 shadow-xl">
+                        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(148,163,255,0.35),transparent_55%)]" aria-hidden />
+                        <div className="relative flex h-full flex-col gap-4">
+                            <h3 className="text-xl font-semibold">{contact.title}</h3>
+                            <p className="text-sm text-slate-200">{contact.description}</p>
+                            <a
+                                className="group inline-flex items-center justify-center gap-2 rounded-full bg-violet-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-violet-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                                href={`mailto:${contact.email}`}
+                            >
+                                {contact.cta}
+                                <ArrowUpRight className="h-4 w-4 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" aria-hidden />
+                            </a>
+                            <div className="mt-auto inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-sm text-slate-100">
+                                <Mail className="h-4 w-4" aria-hidden />
+                                <span>{contact.email}</span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </motion.article>
         </motion.section>


### PR DESCRIPTION
## Summary
- redesign the privacy policy page with a richer hero, information cards, detailed sections and a contact call-to-action
- restructure the privacy policy translations in English and Spanish to provide the new copy blocks used by the layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd4c36fe008330bd0cd908dfeef5e1