### PR TITLE
Derive Supabase password before sending to auth

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -1,6 +1,7 @@
 
 import { createContext, useContext, useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
+import { deriveSupabasePassword } from '../lib/password';
 import type { Session, User } from '@supabase/supabase-js';
 
 type AuthContextType = {
@@ -32,12 +33,14 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const user = session?.user ?? null;
 
     const signIn = async (email: string, password: string) => {
-        const { error } = await supabase.auth.signInWithPassword({ email, password });
+        const derivedPassword = await deriveSupabasePassword(password);
+        const { error } = await supabase.auth.signInWithPassword({ email, password: derivedPassword });
         if (error) throw error;
     };
 
     const signUp = async (email: string, password: string) => {
-        const { data, error } = await supabase.auth.signUp({ email, password });
+        const derivedPassword = await deriveSupabasePassword(password);
+        const { data, error } = await supabase.auth.signUp({ email, password: derivedPassword });
         if (error) throw error;
 
         const userId = data.user?.id;
@@ -46,7 +49,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         }
 
         if (!data.session) {
-            const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+            const { error: signInError } = await supabase.auth.signInWithPassword({ email, password: derivedPassword });
             if (signInError) throw signInError;
         }
     };

--- a/frontend/src/lib/password.ts
+++ b/frontend/src/lib/password.ts
@@ -1,0 +1,35 @@
+const encoder = new TextEncoder();
+const PEPPER = import.meta.env.VITE_PASSWORD_PEPPER ?? 'linknest-pepper';
+
+const toBase64 = (bytes: Uint8Array) => {
+    if (typeof globalThis.btoa === 'function') {
+        let binary = '';
+        bytes.forEach(byte => {
+            binary += String.fromCharCode(byte);
+        });
+        return globalThis.btoa(binary);
+    }
+
+    const buffer = (globalThis as { Buffer?: { from(data: Uint8Array): { toString(encoding: string): string } } }).Buffer;
+    if (buffer) {
+        return buffer.from(bytes).toString('base64');
+    }
+
+    throw new Error('No base64 encoder available');
+};
+
+const hashWithSubtle = async (input: Uint8Array) => {
+    const subtle = globalThis.crypto?.subtle;
+    if (!subtle) {
+        throw new Error('Secure hashing requires Web Crypto support');
+    }
+    const buffer = await subtle.digest('SHA-256', input);
+    return new Uint8Array(buffer);
+};
+
+export const deriveSupabasePassword = async (password: string) => {
+    const prepared = encoder.encode(`${PEPPER}:${password}`);
+    const hashBytes = await hashWithSubtle(prepared);
+    const base64Hash = toBase64(hashBytes).replace(/=+$/, '');
+    return `A${base64Hash}!1a`;
+};

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import { Eye, EyeOff, Loader2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useAuth } from "../context/AuthProvider"
 import { supabase } from "../lib/supabase"
+import { deriveSupabasePassword } from "../lib/password"
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "../components/ui/card"
 import { Label } from "../components/ui/label"
 import { Input } from "../components/ui/input"
@@ -64,13 +65,15 @@ export function ProfilePage() {
 
         try {
             setLoading(true)
-            const { error: signInError } = await supabase.auth.signInWithPassword({ email, password: currentPassword })
+            const derivedCurrent = await deriveSupabasePassword(currentPassword)
+            const { error: signInError } = await supabase.auth.signInWithPassword({ email, password: derivedCurrent })
             if (signInError) {
                 setErrors({ currentPassword: t('profile.password.currentIncorrect') })
                 return
             }
 
-            const { error: updateError } = await supabase.auth.updateUser({ password: newPassword })
+            const derivedNew = await deriveSupabasePassword(newPassword)
+            const { error: updateError } = await supabase.auth.updateUser({ password: derivedNew })
             if (updateError) {
                 setErrors({ global: updateError.message })
                 return


### PR DESCRIPTION
## Summary
- derive a deterministic Supabase password hash on the client before calling auth endpoints
- reuse the derived secret for login, registration, and profile password updates to avoid sending the raw password
- centralize the password derivation logic in a shared utility

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda182e40883308edc3b6e60af3524