### PR TITLE
Add Terms of Service page and footer link

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import ListCategoryPage from './pages/Categories/ListCategoryPage';
 import { UsagePage } from './pages/UsagePage';
 import { AnimatePresence } from "framer-motion";
 import { PrivacyPolicyPage } from './pages/PrivacyPolicyPage';
+import { TermsOfServicePage } from './pages/TermsOfServicePage';
 import { Footer } from './components/Footer.tsx';
 import { ProfilePage } from './pages/ProfilePage.tsx';
 
@@ -25,6 +26,7 @@ function AnimatedRoutes() {
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/register" element={<RegisterPage />} />
                 <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+                <Route path="/terms-of-service" element={<TermsOfServicePage />} />
 
                 <Route element={<PrivateRoute />}>
                     <Route path="/links" element={<ListLinkPage />} />

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -6,11 +6,16 @@ export function Footer() {
     const { t } = useTranslation();
     return (
         <footer className="bg-gray-900/80 backdrop-blur border-t border-gray-800 text-gray-500 text-sm">
-            <div className="container mx-auto flex flex-col sm:flex-row items-center justify-center gap-4 px-4 py-6">
-                <Button asChild variant="link" className="text-indigo-300 p-0 h-auto">
-                    <Link to="/privacy-policy">{t('privacy.title')}</Link>
-                </Button>
-                <span>
+            <div className="container mx-auto flex w-full flex-col items-center gap-4 px-4 py-6 sm:flex-row sm:justify-between">
+                <div className="flex flex-wrap items-center justify-center gap-3 sm:justify-start">
+                    <Button asChild variant="link" className="h-auto p-0 text-indigo-300">
+                        <Link to="/privacy-policy">{t('privacy.title')}</Link>
+                    </Button>
+                    <Button asChild variant="link" className="h-auto p-0 text-indigo-300">
+                        <Link to="/terms-of-service">{t('terms.title')}</Link>
+                    </Button>
+                </div>
+                <span className="text-center sm:text-right">
                     {t('home.footer')}{' '}
                     <a href="https://github.com/tomasrl18" target="_blank" rel="noreferrer" className="text-indigo-400 hover:underline">
                         Tomás

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -267,6 +267,84 @@
             "email": "mailslinknest@gmail.com"
         }
     },
+    "terms": {
+        "title": "Terms of Service",
+        "badge": "Use LinkNest with confidence",
+        "lastUpdated": "Last updated: 5 February 2025",
+        "intro": "These Terms form a binding agreement between you and LinkNest. By creating an account or browsing our public pages you accept them and agree to follow the rules below.",
+        "cards": [
+            {
+                "icon": "scroll",
+                "title": "Clear agreement",
+                "description": "These Terms explain the conditions that apply to every LinkNest account so you always know what to expect."
+            },
+            {
+                "icon": "handshake",
+                "title": "Transparent collaboration",
+                "description": "We outline your rights, our responsibilities and the process we will follow when we update the service."
+            },
+            {
+                "icon": "shield",
+                "title": "Responsible safeguards",
+                "description": "We protect the platform, monitor abuse and may take action when behaviour threatens the safety of other users."
+            }
+        ],
+        "sections": [
+            {
+                "title": "Eligibility and account information",
+                "description": "To keep LinkNest safe you agree to:",
+                "items": [
+                    "Be at least 16 years old or the minimum legal age in your jurisdiction.",
+                    "Provide accurate contact details and keep your credentials confidential.",
+                    "Notify us immediately if you suspect unauthorised access to your account."
+                ]
+            },
+            {
+                "title": "Permitted use",
+                "description": "You may use LinkNest to organise personal or professional resources as long as you:",
+                "items": [
+                    "Do not upload content that infringes the law, third-party rights or contains malicious software.",
+                    "Respect our technical limits and avoid reverse engineering, scraping or automated attacks.",
+                    "Refrain from actions that interfere with the service, other users or our security controls."
+                ]
+            },
+            {
+                "title": "Content ownership",
+                "description": "You always remain the owner of the links, notes and metadata you store. When you save or share them you:",
+                "items": [
+                    "Grant us permission to host, process and display the content within LinkNest.",
+                    "Confirm you have the necessary rights to share or publish what you upload.",
+                    "Understand that deleting data removes it from active systems while backups persist for a limited time."
+                ]
+            }
+        ],
+        "commitments": {
+            "platform": {
+                "title": "Our commitments",
+                "description": "We provide a reliable platform and will:",
+                "items": [
+                    "Maintain LinkNest with reasonable uptime and safeguard your data with industry-standard practices.",
+                    "Communicate material changes to these Terms at least 15 days in advance whenever feasible.",
+                    "Offer export tools so you can retrieve your information before closing your account."
+                ]
+            },
+            "user": {
+                "title": "Your commitments",
+                "description": "To use LinkNest responsibly you agree to:",
+                "items": [
+                    "Comply with these Terms, our policies and applicable laws.",
+                    "Pay any applicable fees described in future paid plans or add-ons.",
+                    "Accept that we may suspend or terminate accounts that violate these rules or harm the community."
+                ]
+            }
+        },
+        "contact": {
+            "title": "Need clarification?",
+            "description": "Our team can help you interpret these Terms or report potential violations. We reply within 72 hours.",
+            "cta": "Contact support",
+            "email": "mailslinknest@gmail.com"
+        }
+    },
     "usage": {
         "total": "Total links",
         "top": "Top visited",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -267,6 +267,84 @@
             "email": "mailslinknest@gmail.com"
         }
     },
+    "terms": {
+        "title": "Condiciones del Servicio",
+        "badge": "Usa LinkNest con confianza",
+        "lastUpdated": "Última actualización: 5 de febrero de 2025",
+        "intro": "Estas Condiciones regulan el uso de LinkNest. Al crear una cuenta o navegar por nuestras páginas públicas las aceptas y te comprometes a seguir las reglas que indicamos a continuación.",
+        "cards": [
+            {
+                "icon": "scroll",
+                "title": "Acuerdo claro",
+                "description": "Estas Condiciones explican las normas que aplican a cada cuenta de LinkNest para que siempre sepas qué esperar."
+            },
+            {
+                "icon": "handshake",
+                "title": "Colaboración transparente",
+                "description": "Detallamos tus derechos, nuestras responsabilidades y el proceso que seguiremos al actualizar el servicio."
+            },
+            {
+                "icon": "shield",
+                "title": "Salvaguardas responsables",
+                "description": "Protegemos la plataforma, monitorizamos abusos y podemos actuar cuando un comportamiento pone en riesgo a otras personas usuarias."
+            }
+        ],
+        "sections": [
+            {
+                "title": "Elegibilidad e información de la cuenta",
+                "description": "Para mantener LinkNest seguro aceptas:",
+                "items": [
+                    "Ser mayor de 16 años o la edad mínima legal en tu jurisdicción.",
+                    "Proporcionar datos de contacto veraces y mantener tus credenciales protegidas.",
+                    "Avisarnos de inmediato si detectas uso no autorizado de tu cuenta."
+                ]
+            },
+            {
+                "title": "Uso permitido",
+                "description": "Puedes utilizar LinkNest para organizar recursos personales o profesionales siempre que:",
+                "items": [
+                    "No subas contenido que infrinja la ley, derechos de terceros o incluya software malicioso.",
+                    "Respetes nuestros límites técnicos y evites la ingeniería inversa, el scraping o ataques automatizados.",
+                    "Te abstengas de acciones que interfieran con el servicio, otras personas usuarias o nuestros controles de seguridad."
+                ]
+            },
+            {
+                "title": "Titularidad del contenido",
+                "description": "Eres dueño de los enlaces, notas y metadatos que almacenas. Al guardarlos o compartirlos:",
+                "items": [
+                    "Nos otorgas permiso para alojar, procesar y mostrar el contenido dentro de LinkNest.",
+                    "Garantizas que tienes los derechos necesarios para compartir o publicar lo que subes.",
+                    "Comprendes que al eliminar datos los quitaremos de los sistemas activos, aunque algunas copias de seguridad puedan persistir temporalmente."
+                ]
+            }
+        ],
+        "commitments": {
+            "platform": {
+                "title": "Nuestros compromisos",
+                "description": "Proporcionamos una plataforma fiable y nos comprometemos a:",
+                "items": [
+                    "Mantener LinkNest con un tiempo de actividad razonable y proteger tus datos con prácticas reconocidas por la industria.",
+                    "Avisarte de cambios relevantes en estas Condiciones con al menos 15 días de antelación siempre que sea posible.",
+                    "Ofrecer herramientas de exportación para que puedas recuperar tu información antes de cerrar la cuenta."
+                ]
+            },
+            "user": {
+                "title": "Tus compromisos",
+                "description": "Para utilizar LinkNest de forma responsable aceptas:",
+                "items": [
+                    "Cumplir estas Condiciones, nuestras políticas y la legislación aplicable.",
+                    "Abonar las tarifas que puedan aplicarse en futuros planes de pago o complementos.",
+                    "Aceptar que podemos suspender o cancelar cuentas que incumplan estas reglas o perjudiquen a la comunidad."
+                ]
+            }
+        },
+        "contact": {
+            "title": "¿Necesitas ayuda?",
+            "description": "Estamos disponibles para resolver dudas sobre estas Condiciones o recibir reportes de incumplimiento. Respondemos en un máximo de 72 horas.",
+            "cta": "Contactar con soporte",
+            "email": "mailslinknest@gmail.com"
+        }
+    },
     "usage": {
         "total": "Total de enlaces",
         "top": "Más visitados",

--- a/frontend/src/pages/TermsOfServicePage.tsx
+++ b/frontend/src/pages/TermsOfServicePage.tsx
@@ -1,0 +1,198 @@
+import { motion } from "framer-motion";
+import type { LucideIcon } from "lucide-react";
+import { ArrowUpRight, CheckCircle2, Clock, Handshake, Mail, ScrollText, ShieldCheck } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { pageVariants, pageTransition } from "../animations/pageVariants";
+
+type TermsCard = {
+    icon: string;
+    title: string;
+    description: string;
+};
+
+type TermsSection = {
+    title: string;
+    description: string;
+    items: string[];
+};
+
+type TermsCommitment = {
+    title: string;
+    description: string;
+    items: string[];
+};
+
+type TermsCommitments = {
+    platform: TermsCommitment;
+    user: TermsCommitment;
+};
+
+type TermsContact = {
+    title: string;
+    description: string;
+    cta: string;
+    email: string;
+};
+
+const iconMap: Record<string, LucideIcon> = {
+    scroll: ScrollText,
+    handshake: Handshake,
+    shield: ShieldCheck,
+};
+
+export function TermsOfServicePage() {
+    const { t } = useTranslation();
+    const rawCards = t("terms.cards", { returnObjects: true });
+    const rawSections = t("terms.sections", { returnObjects: true });
+    const rawCommitments = t("terms.commitments", { returnObjects: true });
+    const rawContact = t("terms.contact", { returnObjects: true });
+
+    const cards = Array.isArray(rawCards) ? (rawCards as TermsCard[]) : [];
+    const sections = Array.isArray(rawSections) ? (rawSections as TermsSection[]) : [];
+    const commitments =
+        rawCommitments && typeof rawCommitments === "object"
+            ? (rawCommitments as TermsCommitments)
+            : {
+                platform: { title: "", description: "", items: [] },
+                user: { title: "", description: "", items: [] },
+            };
+    const platformCommitment = commitments?.platform ?? { title: "", description: "", items: [] };
+    const userCommitment = commitments?.user ?? { title: "", description: "", items: [] };
+    const platformItems = Array.isArray(platformCommitment.items) ? platformCommitment.items : [];
+    const userItems = Array.isArray(userCommitment.items) ? userCommitment.items : [];
+    const contact =
+        rawContact && typeof rawContact === "object"
+            ? (rawContact as TermsContact)
+            : { title: "", description: "", cta: "", email: "" };
+
+    return (
+        <motion.section
+            variants={pageVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            transition={pageTransition}
+            className="relative min-h-[calc(100dvh-80px)] overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-4 pb-20 pt-16"
+        >
+            <div className="absolute inset-0 -z-10">
+                <div className="absolute -left-24 top-16 h-72 w-72 rounded-full bg-violet-500/25 blur-3xl" aria-hidden />
+                <div className="absolute bottom-0 right-0 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" aria-hidden />
+            </div>
+
+            <motion.article
+                initial={{ y: 20, opacity: 0 }}
+                animate={{ y: 0, opacity: 1 }}
+                transition={{ type: "spring", stiffness: 140, damping: 18, delay: 0.15 }}
+                className="relative mx-auto flex w-full max-w-5xl flex-col gap-10 rounded-[32px] border border-white/10 bg-white/5 p-8 text-slate-200 shadow-2xl backdrop-blur-xl md:p-10"
+            >
+                <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-8 md:p-10">
+                    <div className="absolute inset-x-0 -top-40 h-80 bg-gradient-to-b from-violet-500/25 via-violet-500/10 to-transparent blur-3xl" aria-hidden />
+                    <div className="relative space-y-6">
+                        <span className="inline-flex items-center gap-2 rounded-full border border-violet-400/30 bg-violet-500/10 px-4 py-1 text-xs font-medium uppercase tracking-[0.3em] text-violet-200">
+                            <ScrollText className="h-4 w-4" aria-hidden />
+                            {t("terms.badge")}
+                        </span>
+                        <div className="space-y-4">
+                            <h1 className="text-3xl font-bold text-slate-50 md:text-4xl">{t("terms.title")}</h1>
+                            <p className="text-base leading-relaxed text-slate-300 md:text-lg">{t("terms.intro")}</p>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-3 text-sm text-slate-400">
+                            <div className="flex items-center gap-2 rounded-full bg-slate-800/60 px-3 py-1.5">
+                                <Clock className="h-4 w-4" aria-hidden />
+                                <span>{t("terms.lastUpdated")}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-3">
+                    {cards.map((card, idx) => {
+                        const Icon = iconMap[card.icon] ?? ShieldCheck;
+
+                        return (
+                            <div
+                                key={`${card.title}-${idx}`}
+                                className="group relative overflow-hidden rounded-2xl border border-slate-700/60 bg-slate-900/70 p-6 shadow-lg transition hover:border-violet-400/60 hover:bg-slate-900"
+                            >
+                                <span className="mb-5 inline-flex h-12 w-12 items-center justify-center rounded-full bg-violet-500/15 text-violet-200 ring-1 ring-inset ring-violet-400/40">
+                                    <Icon className="h-6 w-6" aria-hidden />
+                                </span>
+                                <h2 className="text-lg font-semibold text-slate-100">{card.title}</h2>
+                                <p className="mt-2 text-sm leading-relaxed text-slate-300">{card.description}</p>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <div className="grid gap-6">
+                    {sections.map((section, idx) => (
+                        <div
+                            key={`${section.title}-${idx}`}
+                            className="rounded-3xl border border-slate-700/60 bg-slate-900/60 p-6 shadow-lg md:p-8"
+                        >
+                            <h3 className="text-xl font-semibold text-slate-100">{section.title}</h3>
+                            <p className="mt-2 text-sm text-slate-300">{section.description}</p>
+                            <ul className="mt-4 space-y-3">
+                                {section.items.map((item, itemIdx) => (
+                                    <li key={`${section.title}-${itemIdx}`} className="flex items-start gap-3 text-sm text-slate-200">
+                                        <CheckCircle2 className="mt-1 h-4 w-4 flex-shrink-0 text-violet-300" aria-hidden />
+                                        <span className="leading-relaxed text-slate-300">{item}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    ))}
+                </div>
+
+                <div className="grid gap-6 md:grid-cols-2">
+                    <div className="rounded-3xl border border-slate-700/60 bg-slate-900/60 p-6 shadow-lg md:p-8">
+                        <h3 className="text-xl font-semibold text-slate-100">{platformCommitment.title}</h3>
+                        <p className="mt-2 text-sm text-slate-300">{platformCommitment.description}</p>
+                        <ul className="mt-4 space-y-3">
+                            {platformItems.map((item, idx) => (
+                                <li key={`platform-${idx}`} className="flex items-start gap-3 text-sm text-slate-200">
+                                    <CheckCircle2 className="mt-1 h-4 w-4 flex-shrink-0 text-emerald-300" aria-hidden />
+                                    <span className="leading-relaxed text-slate-300">{item}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="rounded-3xl border border-slate-700/60 bg-slate-900/60 p-6 shadow-lg md:p-8">
+                        <h3 className="text-xl font-semibold text-slate-100">{userCommitment.title}</h3>
+                        <p className="mt-2 text-sm text-slate-300">{userCommitment.description}</p>
+                        <ul className="mt-4 space-y-3">
+                            {userItems.map((item, idx) => (
+                                <li key={`user-${idx}`} className="flex items-start gap-3 text-sm text-slate-200">
+                                    <CheckCircle2 className="mt-1 h-4 w-4 flex-shrink-0 text-amber-300" aria-hidden />
+                                    <span className="leading-relaxed text-slate-300">{item}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="relative overflow-hidden rounded-3xl border border-violet-400/30 bg-gradient-to-br from-violet-500/20 via-slate-900 to-slate-950 p-6 text-slate-100 shadow-xl">
+                    <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(148,163,255,0.35),transparent_55%)]" aria-hidden />
+                    <div className="relative flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <div className="max-w-2xl space-y-2">
+                            <h3 className="text-xl font-semibold">{contact.title}</h3>
+                            <p className="text-sm text-slate-200">{contact.description}</p>
+                            <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-sm text-slate-100">
+                                <Mail className="h-4 w-4" aria-hidden />
+                                <span>{contact.email}</span>
+                            </div>
+                        </div>
+                        <a
+                            className="group inline-flex items-center justify-center gap-2 rounded-full bg-violet-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-violet-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+                            href={`mailto:${contact.email}`}
+                        >
+                            {contact.cta}
+                            <ArrowUpRight className="h-4 w-4 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" aria-hidden />
+                        </a>
+                    </div>
+                </div>
+            </motion.article>
+        </motion.section>
+    );
+}


### PR DESCRIPTION
## Summary
- create a Terms of Service page that mirrors the privacy policy presentation and reads its content from the i18n files
- add English and Spanish translations for the new terms page and expose its public route
- update the footer to show quick access links to privacy policy and terms of service

## Testing
- npm run lint *(shows existing react-refresh warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfeed5f4e0833080136cda188e4171